### PR TITLE
enhance acceptance test for consul_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ deal with DNS.
 During the work on this project we run into several issues. They are documented below
 
 * https://github.com/puppetlabs/puppetlabs-puppetdb/pull/251
+* https://github.com/puppetlabs/puppetlabs-apt/pull/822
 * https://github.com/theforeman/puppet-puppet/pull/600
 * https://github.com/theforeman/puppet-foreman/issues/649
 * https://github.com/theforeman/puppet-puppet/pull/647
@@ -191,6 +192,8 @@ The goal is to have acceptance tests for all profiles. The following are known t
 
 ```sh
 PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/node_exporter_spec.rb
+PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/node_exporter_spec.rb
+PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/node_exporter_spec.rb
 
 PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/consulserver_spec.rb
 PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/consulserver_spec.rb
@@ -211,3 +214,8 @@ PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKE
 PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/choriaserver_spec.rb
 PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker\,hostname=puppet.local} BEAKER_destroy=yes bundle exec rspec spec/acceptance/choriaserver_spec.rb
 ```
+
+### Limitations
+
+* node\_exporter profile on Puppet 6 fails because it generates TLS certificates which is currently Puppet 5 specific
+* node\_exporter profiles on Debian 9 fails because of [recent gpg changes](https://github.com/puppetlabs/puppetlabs-apt/pull/822) that are not compatible to puppetlabs/apt 6.1.1

--- a/modules/profiles/spec/acceptance/node_exporter_spec.rb
+++ b/modules/profiles/spec/acceptance/node_exporter_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper_acceptance'
 
 describe 'profiles::node_exporter class' do
   shell('puppet cert generate puppet.local --dns_alt_names=puppet.local,puppet,puppetdb,puppetdb.local')
+  install_module_from_forge('puppetlabs-apt', '>= 6.1.1 < 7.0.0') if fact('os.family') == 'Debian'
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'works idempotently with no errors' do


### PR DESCRIPTION
Fixes https://github.com/bastelfreak/puppetcontrolrepo/issues/29

Adds acceptance tests for:
* CentOS 7
* Ubuntu 18.04
* Ubuntu 16.04

The acceptance test does not work on Debian 9 because of recent gpg
updates. Also Puppet 6 fails for all platforms because of the way we
generate certificates.